### PR TITLE
Update minimatch to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "tape": "^3.0.3"
   },
   "dependencies": {
-    "minimatch": "^2.0.1"
+    "minimatch": "^3.0.3"
   }
 }


### PR DESCRIPTION
There is a security issue with version < 3.0.2
see https://nodesecurity.io/advisories/118
